### PR TITLE
fix: prevent IndexError on some inputs to TextInput.move_cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+-   Fixes issue where text area was aggressively capturing mouse events and not responding to mouse up events,
+    which would cause issues if your App had widgets other than the TextArea ([#42](https://github.com/tconbeer/textual-textarea/issues/42)).
+-   Fixes an issue where <kbd>PageUp</kbd> could cause a crash ([#46](https://github.com/tconbeer/textual-textarea/issues/46)).
+
 ## [0.3.0] - 2023-06-19
 
 -   Select text using click and drag ([#8](https://github.com/tconbeer/textual-textarea/issues/8)).

--- a/src/textual_textarea/textarea.py
+++ b/src/textual_textarea/textarea.py
@@ -518,10 +518,10 @@ class TextInput(Static, can_focus=True):
 
     def move_cursor(self, x: int, y: int) -> None:
         max_y = len(self.lines) - 1
-        safe_y = min(max_y, y)
+        safe_y = max(0, min(max_y, y))
         max_x = len(self.lines[safe_y]) - 1
-        safe_x = min(max_x, x)
-        self.cursor = Cursor(lno=max(0, safe_y), pos=max(0, safe_x))
+        safe_x = max(0, min(max_x, x))
+        self.cursor = Cursor(lno=safe_y, pos=safe_x)
         self.update(self._content)
 
 

--- a/tests/functional_tests/test_textarea.py
+++ b/tests/functional_tests/test_textarea.py
@@ -121,6 +121,30 @@ async def test_keys(
         assert input.cursor == expected_cursor
 
 
+@pytest.mark.asyncio
+async def test_move_cursor(app: App) -> None:
+    async with app.run_test():
+        ta = app.query_one(TextArea)
+        ti = ta.text_input
+        ti.lines = [f"{'X' * i} " for i in range(10)]
+
+        assert ta.cursor == Cursor(0, 0)
+        for i in range(10):
+            ti.move_cursor(100, i)
+            assert ta.cursor == Cursor(i, i)
+            ti.move_cursor(0, i)
+            assert ta.cursor == Cursor(i, 0)
+
+        ti.move_cursor(-100, -100)
+        assert ta.cursor == Cursor(0, 0)
+
+        ti.move_cursor(-10, 5)
+        assert ta.cursor == Cursor(5, 0)
+
+        ti.move_cursor(5, -5)
+        assert ta.cursor == Cursor(0, 0)
+
+
 @pytest.mark.parametrize(
     "starting_anchor,starting_cursor,expected_clipboard",
     [


### PR DESCRIPTION
fixes #46 