### PR TITLE
Expand user home directories in paths.

### DIFF
--- a/src/textual_textarea/textarea.py
+++ b/src/textual_textarea/textarea.py
@@ -1,4 +1,5 @@
 from math import ceil, floor
+from os.path import expanduser
 from typing import List, Tuple, Union
 
 import pyperclip
@@ -701,9 +702,10 @@ class TextArea(Widget, can_focus=True, can_focus_children=False):
         """
         Handle the submit event for the Save and Open modals.
         """
+        expanded_path = expanduser(message.input.value)
         if message.input.id == "textarea__save_input":
             try:
-                with open(message.input.value, "w") as f:
+                with open(expanded_path, "w") as f:
                     f.write(self.text)
             except OSError as e:
                 self.app.push_screen(
@@ -717,7 +719,7 @@ class TextArea(Widget, can_focus=True, can_focus_children=False):
                 )
         elif message.input.id == "textarea__open_input":
             try:
-                with open(message.input.value, "r") as f:
+                with open(expanded_path, "r") as f:
                     contents = f.read()
             except OSError as e:
                 self.app.push_screen(


### PR DESCRIPTION
This calls `os.path.expanduser` on the input to the save/load dialog, which will expand user home directory placeholders in the path root position, such as `~/foo` on Unix systems, which will then get expanded to `/home/$USER/foo`.

See: https://docs.python.org/3/library/os.path.html#os.path.expanduser