### PR TITLE
fix: add 10-minute timeout to gha jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
   test-windows:
     name: Windows - 3.10
     runs-on: Windows-latest
+    timeout-minutes: 10
     steps:
       - name: Check out Repo
         uses: actions/checkout@v3
@@ -39,6 +40,7 @@ jobs:
   test:
     name: ${{ matrix.os }} - ${{ matrix.py }}
     runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Fuzzing sometimes hangs; this prevents bad things.