### PR TITLE
Show the full path when entering the save dialog

### DIFF
--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -1135,7 +1135,7 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
             label = self.footer.query_one(Label)
             if message.validation_result and not message.validation_result.is_valid:
                 label.update(";".join(message.validation_result.failure_descriptions))
-            else:
+            elif message.validation_result and message.validation_result.is_valid:
                 label.update(abspath(message.input.value))
 
     @on(Input.Submitted, "#textarea__save_input")

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -4,7 +4,7 @@ import re
 from collections import deque
 from dataclasses import dataclass
 from math import ceil, floor
-from os.path import expanduser
+from os.path import abspath, expanduser
 from typing import TYPE_CHECKING, Any, Callable, Deque, Literal, Sequence
 
 import pyperclip
@@ -1136,7 +1136,7 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
             if message.validation_result and not message.validation_result.is_valid:
                 label.update(";".join(message.validation_result.failure_descriptions))
             else:
-                label.update("")
+                label.update(abspath(message.input.value))
 
     @on(Input.Submitted, "#textarea__save_input")
     def save_file(self, message: Input.Submitted) -> None:


### PR DESCRIPTION
Show the full path at the validation label for the save dialog when the input is valid.

Solves issue [232](https://github.com/tconbeer/textual-textarea/issues/232 )

All tests run ok, and basic testing from my side (via pointing Harlequin to textual-textarea with these changes) gives the anticipated result.