### PR TITLE
refactor/incorporate upstream updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 -   Adds bindings for `ctrl+shift+home` and `ctrl+shift+end` to select while moving to document start/end.
+-   Uses the new, native undo and redo functionality provided by the Textual TextArea widget. This has some subtly different behavior ([#240](https://github.com/tconbeer/textual-textarea/issues/240).
 
 ## [0.12.0] - 2024-04-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+-   Adds bindings for `ctrl+shift+home` and `ctrl+shift+end` to select while moving to document start/end.
+
 ## [0.12.0] - 2024-04-17
 
 -   Show the computed filepath in the Save and Open widgets ([#232](https://github.com/tconbeer/textual-textarea/issues/232) - thank you [@bjornasm](https://github.com/bjornasm)!).

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -86,8 +86,8 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
         Binding("ctrl+right", "cursor_word_right", "cursor word right", show=False),
         Binding("home", "cursor_line_start", "cursor line start", show=False),
         Binding("end", "cursor_line_end", "cursor line end", show=False),
-        Binding("ctrl+home", "cursor_doc_start", "cursor line start", show=False),
-        Binding("ctrl+end", "cursor_doc_end", "cursor line end", show=False),
+        Binding("ctrl+home", "cursor_doc_start", "cursor doc start", show=False),
+        Binding("ctrl+end", "cursor_doc_end", "cursor doc end", show=False),
         Binding("pageup", "cursor_page_up", "cursor page up", show=False),
         Binding("pagedown", "cursor_page_down", "cursor page down", show=False),
         # scrolling
@@ -114,6 +114,18 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
         ),
         Binding(
             "shift+end", "cursor_line_end(True)", "cursor line end select", show=False
+        ),
+        Binding(
+            "ctrl+shift+home",
+            "cursor_doc_start(True)",
+            "select to cursor doc start",
+            show=False,
+        ),
+        Binding(
+            "ctrl+shift+end",
+            "cursor_doc_end(True)",
+            "select to cursor doc end",
+            show=False,
         ),
         Binding("shift+up", "cursor_up(True)", "cursor up select", show=False),
         Binding("shift+down", "cursor_down(True)", "cursor down select", show=False),
@@ -351,15 +363,21 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
             self.action_delete_line()
         self.delete(*self.selection)
 
-    def action_cursor_doc_start(self) -> None:
+    def action_cursor_doc_start(self, select: bool = False) -> None:
         self.post_message(TextAreaHideCompletionList())
-        self.selection = Selection(start=(0, 0), end=(0, 0))
+        if select:
+            self.selection = Selection(start=self.selection.start, end=(0, 0))
+        else:
+            self.selection = Selection(start=(0, 0), end=(0, 0))
 
-    def action_cursor_doc_end(self) -> None:
+    def action_cursor_doc_end(self, select: bool = False) -> None:
         self.post_message(TextAreaHideCompletionList())
         lno = self.document.line_count - 1
         loc = (lno, len(self.document.get_line(lno)))
-        self.selection = Selection(start=loc, end=loc)
+        if select:
+            self.selection = Selection(start=self.selection.start, end=loc)
+        else:
+            self.selection = Selection(start=loc, end=loc)
 
     def action_delete_line(self) -> None:
         self.post_message(TextAreaHideCompletionList())

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -950,7 +950,7 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
         """
         self.text_input.replace(
             text,
-            *list(sorted(self.text_input.selection)),
+            *self.text_input.selection,
             maintain_selection_offset=False,
         )
 

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -443,16 +443,21 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
                     )
             # add comment tokens to all lines
             else:
-                indent = min(
+                comment_indent = min(
                     [indent for indent, line in zip(indents, stripped_lines) if line]
                 )
+                insertion = f"{self.inline_comment_marker} "
                 for lno, stripped_line in enumerate(stripped_lines, start=first[0]):
                     if stripped_line:
-                        self.insert(
-                            f"{self.inline_comment_marker} ",
-                            location=(lno, indent),
-                            maintain_selection_offset=True,
-                        )
+                        # insert one character at a time, to create a single undo-able
+                        # batch of edits.
+                        # See https://github.com/Textualize/textual/issues/4428
+                        for i, char in enumerate(insertion):
+                            self.insert(
+                                char,
+                                location=(lno, comment_indent + i),
+                                maintain_selection_offset=True,
+                            )
 
     def action_undo(self) -> None:
         self.post_message(TextAreaHideCompletionList())

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -1,4 +1,5 @@
 from typing import Type, Union
+from unittest.mock import MagicMock
 
 import pytest
 from textual.app import App, ComposeResult
@@ -45,3 +46,17 @@ def app() -> App:
 def app_all_clipboards(request: pytest.FixtureRequest) -> App:
     app = TextEditorApp(use_system_clipboard=request.param)
     return app
+
+
+@pytest.fixture(autouse=True)
+def mock_pyperclip(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock = MagicMock()
+    mock.determine_clipboard.return_value = mock.copy, mock.paste
+
+    def set_paste(x: str) -> None:
+        mock.paste.return_value = x
+
+    mock.copy.side_effect = set_paste
+    monkeypatch.setattr("textual_textarea.text_editor.pyperclip", mock)
+
+    return mock

--- a/tests/functional_tests/test_textarea.py
+++ b/tests/functional_tests/test_textarea.py
@@ -297,6 +297,7 @@ async def test_copy_paste(
         assert ta.text == original_text
 
         await pilot.press("ctrl+u")
+        await pilot.pause()
         assert eq(ti.clipboard, expected_clipboard)
         assert ta.selection == Selection(starting_selection.end, starting_selection.end)
         assert ta.text == original_text
@@ -310,17 +311,20 @@ async def test_copy_paste(
         assert ta.text == original_text
 
         await pilot.press("ctrl+u")
+        await pilot.pause()
         assert ta.selection == Selection(expected_paste_loc, expected_paste_loc)
         assert eq(ti.clipboard, expected_clipboard)
         assert ta.text == expected_clipboard
 
         await pilot.press("ctrl+a")
         await pilot.press("ctrl+x")
+        await pilot.pause()
         assert ta.selection == Selection((0, 0), (0, 0))
         assert eq(ti.clipboard, expected_clipboard)
         assert ta.text == ""
 
         await pilot.press("ctrl+v")
+        await pilot.pause()
         assert eq(ti.clipboard, expected_clipboard)
         assert ta.text == expected_clipboard
         assert ta.selection == Selection(expected_paste_loc, expected_paste_loc)

--- a/tests/functional_tests/test_textarea.py
+++ b/tests/functional_tests/test_textarea.py
@@ -333,64 +333,34 @@ async def test_undo_redo(app: App) -> None:
         ti = ta.text_input
         assert ti
         assert ti.has_focus
-        assert ti.undo_stack
-        assert len(ti.undo_stack) == 1
-        assert ti.undo_stack[0].selection == Selection((0, 0), (0, 0))
-        assert not ti.redo_stack
 
         for char in "foo":
             await pilot.press(char)
         await pilot.pause(0.6)
-        assert ti.undo_stack
-        assert len(ti.undo_stack) == 2
-        assert ti.undo_stack[-1].text == "foo"
-        assert ti.undo_stack[-1].selection == Selection((0, 3), (0, 3))
 
         await pilot.press("enter")
         for char in "bar":
             await pilot.press(char)
         await pilot.pause(0.6)
-        assert ti.undo_stack
-        assert len(ti.undo_stack) == 3
-        assert ti.undo_stack[-1].text == "foo\nbar"
-        assert ti.undo_stack[-1].selection == Selection((1, 3), (1, 3))
 
         await pilot.press("ctrl+z")
-        assert ti.undo_stack
-        assert len(ti.undo_stack) == 2
-        assert ti.undo_stack[-1].text == "foo"
+        assert ta.text == "foo\n"
+        assert ta.selection == Selection((1, 0), (1, 0))
+
+        await pilot.press("ctrl+z")
         assert ta.text == "foo"
         assert ta.selection == Selection((0, 3), (0, 3))
-        assert ti.redo_stack
-        assert len(ti.redo_stack) == 1
-        assert ti.redo_stack[-1].text == "foo\nbar"
 
         await pilot.press("ctrl+z")
-        assert ti.undo_stack
-        assert len(ti.undo_stack) == 1
-        assert ti.undo_stack[-1].text == ""
         assert ta.text == ""
         assert ta.selection == Selection((0, 0), (0, 0))
-        assert ti.redo_stack
-        assert len(ti.redo_stack) == 2
-        assert ti.redo_stack[-1].text == "foo"
 
         await pilot.press("ctrl+y")
-        assert ti.undo_stack
-        assert len(ti.undo_stack) == 2
-        assert ti.undo_stack[-1].text == "foo"
         assert ta.text == "foo"
         assert ta.selection == Selection((0, 3), (0, 3))
-        assert ti.redo_stack
-        assert len(ti.redo_stack) == 1
-        assert ti.redo_stack[-1].text == "foo\nbar"
 
         await pilot.press("z")
-        await pilot.pause(0.6)
-        assert len(ti.undo_stack) == 3
-        assert ti.undo_stack[-1].text == "fooz"
         assert ta.text == "fooz"
-        assert not ti.redo_stack
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- feat: add ctrl_shift_home and ctrl_shift_end bindings
- refactor: use native undo/redo, close #240
- fix: batch undo edits for comment toggles
- fix #242: remove backwards insertion check
