### PR TITLE
fix: pass validate_on as a set, not list, for goto input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixes a TypeError raised by Textual >= v0.76 from the goto input validator.
+
 ## [0.14.1] - 2024-08-15
 
 - Fixes a bug where uncommenting a line using the `toggle_comment` action would leave behind a space in languages with comment markers that are longer than one character ([tconbeer/harlequin#616](https://github.com/tconbeer/harlequin/issues/616)).

--- a/src/textual_textarea/goto_input.py
+++ b/src/textual_textarea/goto_input.py
@@ -54,7 +54,7 @@ class GotoLineInput(CancellableInput):
             validators=GotoLineValidator(
                 max_line_number=max_line_number, min_line_number=min_line_number
             ),
-            validate_on=["changed"],
+            validate_on={"changed"},
             id=id,
             classes=classes,
         )


### PR DESCRIPTION
work-around for https://github.com/Textualize/textual/pull/4868