### PR TITLE
refactor: use Click.chain for double- and triple-click selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Double-, triple-, and quadruple-click selection now uses Textual's `Click.chain`, instead of tracking consecutive clicks with a timer ([harlequin/#708](https://github.com/tconbeer/harlequin/issues/708)).
+- Fixes a bug where double-clicking a word shortly after double-clicking a different word would select the line or the whole document, instead of the second word.
+
 ## [0.17.2] - 2025-10-24
 
 - This widget no longer stops (prevents bubbling of) the Changed and SelectionChanged events.

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -15,7 +15,6 @@ from textual.binding import Binding
 from textual.events import Paste
 from textual.message import Message
 from textual.reactive import reactive
-from textual.timer import Timer
 from textual.widget import Widget
 from textual.widgets import Input, Label, OptionList, TextArea
 from textual.widgets.text_area import Location, Selection, SyntaxAwareDocument
@@ -208,9 +207,6 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
         )
         self.cursor_blink = False if self.app.is_headless else True
         self.use_system_clipboard = use_system_clipboard
-        self.double_click_location: Location | None = None
-        self.double_click_timer: Timer | None = None
-        self.consecutive_clicks: int = 0
         self.system_copy: Callable[[Any], None] | None = None
         self.system_paste: Callable[[], str] | None = None
 
@@ -265,42 +261,23 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
         self.post_message(TextAreaHideCompletionList())
-        target = self.get_target_document_location(event)
-        if (
-            self.double_click_location is not None
-            and self.double_click_location == target
-        ):
-            event.prevent_default()
-            self._selecting = True
-            self.capture_mouse()
-            self._pause_blink(visible=True)
 
-    def on_mouse_up(self, event: events.MouseUp) -> None:
-        target = self.get_target_document_location(event)
-        if (
-            self.consecutive_clicks > 0
-            and self.double_click_location is not None
-            and self.double_click_location == target
-        ):
-            if self.consecutive_clicks == 1:
-                self.action_select_word()
-            elif self.consecutive_clicks == 2:
-                self.action_select_line()
-                self.action_cursor_right(select=True)
-            else:
-                self.action_select_all()
-            self.consecutive_clicks += 1
+    def on_click(self, event: events.Click) -> None:
+        """
+        Expand the selection for repeated clicks at the same location: a double
+        click selects the word under the cursor, a triple click selects the line,
+        and any further clicks select the whole document. Textual counts the
+        clicks in the chain for us.
+        """
+        if event.chain == 1:
+            return
+        elif event.chain == 2:
+            self.action_select_word()
+        elif event.chain == 3:
+            self.action_select_line()
+            self.action_cursor_right(select=True)
         else:
-            self.history.checkpoint()
-            self.double_click_location = target
-            self.consecutive_clicks += 1
-
-        if self.double_click_timer is not None:
-            self.double_click_timer.reset()
-        else:
-            self.double_click_timer = self.set_timer(
-                delay=0.5, callback=self._clear_double_click, name="double_click_timer"
-            )
+            self.action_select_all()
 
     def on_paste(self, event: Paste) -> None:
         event.prevent_default()
@@ -473,11 +450,6 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
     def action_redo(self) -> None:
         self.post_message(TextAreaHideCompletionList())
         super().action_redo()
-
-    def _clear_double_click(self) -> None:
-        self.consecutive_clicks = 0
-        self.double_click_location = None
-        self.double_click_timer = None
 
     def _copy_selection(self) -> None:
         if self.selected_text:

--- a/tests/functional_tests/test_textarea.py
+++ b/tests/functional_tests/test_textarea.py
@@ -4,6 +4,9 @@ from typing import List
 
 import pytest
 from textual.app import App
+from textual.events import MouseDown, MouseUp
+from textual.pilot import _get_mouse_message_arguments
+from textual.widget import Widget
 from textual.widgets.text_area import Selection
 
 from textual_textarea import TextEditor
@@ -461,3 +464,76 @@ async def test_toggle_comment(app: App) -> None:
         await pilot.press("ctrl+a")
         await pilot.press("ctrl+underscore")
         assert ta.text == "one\ntwo\n\nthree"
+
+
+async def _click(app: App, widget: Widget, offset: tuple[int, int]) -> None:
+    """
+    Post the mouse events for a single click, and let Textual count the click
+    chain itself. `pilot.click(times=n)` sets `chain` on the Click event directly,
+    so it can't show how consecutive clicks at different locations interact.
+    """
+    kwargs = _get_mouse_message_arguments(widget, offset, button=1)
+    app.post_message(MouseDown(**kwargs))
+    app.post_message(MouseUp(**kwargs))
+
+
+@pytest.mark.asyncio
+async def test_click_chain_selection(app: App) -> None:
+    """
+    A single click moves the cursor; repeated clicks at the same location expand
+    the selection to the word, then the line, then the whole document.
+    """
+    async with app.run_test() as pilot:
+        ta = app.query_one("#ta", expect_type=TextEditor)
+        ta.text = "select foo\nfrom bar"
+        ta.selection = Selection((0, 0), (0, 0))
+        await pilot.pause()
+        text_input = ta.text_input
+        assert text_input is not None
+
+        # the text starts after a four-character gutter; click inside "foo"
+        offset = (12, 0)
+
+        await _click(app, text_input, offset)
+        await pilot.pause()
+        assert ta.selection == Selection((0, 8), (0, 8))
+
+        await _click(app, text_input, offset)
+        await pilot.pause()
+        assert ta.selection == Selection((0, 7), (0, 10))
+
+        await _click(app, text_input, offset)
+        await pilot.pause()
+        assert ta.selection == Selection((0, 0), (1, 0))
+
+        await _click(app, text_input, offset)
+        await pilot.pause()
+        assert ta.selection == Selection((0, 0), (1, 8))
+
+
+@pytest.mark.asyncio
+async def test_click_chain_resets_at_a_new_location(app: App) -> None:
+    """
+    Double-clicking a word, then double-clicking a different word, selects the
+    second word: the second pair of clicks starts a new chain instead of
+    continuing the first one.
+    """
+    async with app.run_test() as pilot:
+        ta = app.query_one("#ta", expect_type=TextEditor)
+        ta.text = "select foo\nfrom barbarbar"
+        ta.selection = Selection((0, 0), (0, 0))
+        await pilot.pause()
+        text_input = ta.text_input
+        assert text_input is not None
+
+        # double click "foo"
+        for _ in range(2):
+            await _click(app, text_input, (12, 0))
+        await pilot.pause()
+        assert ta.selection == Selection((0, 7), (0, 10))
+
+        # double click "barbarbar" on the next line
+        for _ in range(2):
+            await _click(app, text_input, (12, 1))
+        await pilot.pause()
+        assert ta.selection == Selection((1, 5), (1, 14))


### PR DESCRIPTION
Companion to [tconbeer/harlequin#708](https://github.com/tconbeer/harlequin/issues/708) (harlequin PR: tconbeer/harlequin#1003).

**What**

- `TextAreaPlus` reads Textual's `Click.chain` in a new `on_click` handler: chain 2 selects the word, chain 3 selects the line, chain 4+ selects the document. `double_click_location`, `double_click_timer`, `consecutive_clicks`, and `_clear_double_click` are all gone, along with the `Timer` import.
- `on_mouse_down` now only hides the completion list.

**Why**

Textual counts consecutive clicks at the same offset on the App (`CLICK_CHAIN_TIME_THRESHOLD` is 0.5s — the same window this widget was reimplementing).

This also fixes a real bug. The old `consecutive_clicks` counter was only ever incremented, never reset when a click landed at a new location, so double-clicking a word shortly after double-clicking a *different* word selected the line or the whole document instead of the second word:

| | selection after double-clicking `foo`, then `barbarbar` on the next line |
| --- | --- |
| before | `(0,0)–(1,14)` — the whole document |
| after | `(1,5)–(1,14)` — just `barbarbar` |

**Tradeoff:** `on_mouse_down` previously called `prevent_default()` on the second and later mouse-downs of a chain, which kept the previous selection highlighted while the button was held. Without that, the selection collapses on mouse-down and is re-applied when the click completes, so there's a brief flicker while the button is held on a triple click. Restoring it would mean tracking click locations again, which is what this PR removes.

**Tests**

Two new tests post real `MouseDown`/`MouseUp` pairs through `App.on_event` so that Textual computes the chain itself — `pilot.click(times=n)` sets `chain` on the Click event directly, which can't show how clicks at different locations interact:

- `test_click_chain_selection` — escalating clicks select word, then line, then all.
- `test_click_chain_resets_at_a_new_location` — the bug above; fails on `main`, passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)