### PR TITLE
fix: point mypy at Python 3.10, the actual supported floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ select = ["A", "B", "E", "F", "I"]
 
 [tool.mypy]
 
-python_version = "3.9"
+python_version = "3.10"
 files = [
     "src/**/*.py",
     "tests/**/*.py",


### PR DESCRIPTION
`[tool.mypy] python_version` was still `3.9` while `requires-python` is `>=3.10,<3.15`.

Under 3.9 semantics, mypy rejects the `match` statements in the pytest source that the `mirrors-mypy` pre-commit hook installs as an `additional_dependency`, so the hook aborted before it checked any of this project's files:

```
_pytest/logging.py:202:5: error: Pattern matching is only supported in Python 3.10 and greater  [syntax]
Found 1 error in 1 file (errors prevented further checking)
```

CI never noticed because the static workflow runs mypy through `uv` against the locked environment rather than through the hook — so `mypy --no-incremental` passed while the hook was dead locally.

At `3.10`, both paths pass: `mypy --no-incremental` reports no issues in 25 source files, and `pre-commit run mypy --all-files` passes. No source changes were needed.

Note that `[tool.ruff] target-version = "py39"` is stale in the same way. Left alone here since bumping it changes lint behavior (pyupgrade-style rules, `B905` strict-zip, etc.) rather than just fixing a broken tool — happy to do it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AStKXYW2f2141B8gbgbAwQ