### PR TITLE
Upgrade to Textual 8.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- **Breaking:** drops support for Textual &lt; 8.2.8.
+- Fixes a bug where focusing the `TextEditor` while it already had focus would dismiss an open autocomplete list. `TextEditor.focus()` now focuses the inner `TextArea` directly, instead of taking focus and forwarding it.
+- Adds <kbd>ctrl+backspace</kbd> and <kbd>alt+backspace</kbd> (delete word left) and <kbd>alt+delete</kbd> (delete word right), using Textual's own actions.
+- Adds <kbd>cmd</kbd> aliases for cut, copy, paste, undo, and redo, which Textual reports on terminals that support the Kitty keyboard protocol.
+- Copying now also writes to Textual's clipboard (which emits OSC 52), so copy works over ssh and in terminals where pyperclip has no backend.
+
 ## [0.17.3] - 2026-08-03
 
 - Double-, triple-, and quadruple-click selection now uses Textual's `Click.chain`, instead of tracking consecutive clicks with a timer ([harlequin/#708](https://github.com/tconbeer/harlequin/issues/708)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- **Breaking:** drops support for Textual &lt; 8.2.8.
+- **Breaking:** drops support for Textual &lt; 7.3.
 - Fixes a bug where focusing the `TextEditor` while it already had focus would dismiss an open autocomplete list. `TextEditor.focus()` now focuses the inner `TextArea` directly, instead of taking focus and forwarding it.
 - Adds <kbd>ctrl+backspace</kbd> and <kbd>alt+backspace</kbd> (delete word left) and <kbd>alt+delete</kbd> (delete word right), using Textual's own actions.
 - Adds <kbd>cmd</kbd> aliases for cut, copy, paste, undo, and redo, which Textual reports on terminals that support the Kitty keyboard protocol.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Full-featured text editor experience with VS-Code-like bindings, in your Textual
 - Syntax highlighting and support for Pygments themes.
 - Move cursor and scroll with mouse or keys (including <kbd>ctrl+arrow</kbd>, <kbd>PgUp/Dn</kbd>,  <kbd>ctrl+Home/End</kbd>).
 - Open (<kbd>ctrl+o</kbd>) and save (<kbd>ctrl+s</kbd>) files.
-- Cut (<kbd>ctrl+x</kbd>), copy (<kbd>ctrl+c</kbd>), paste (<kbd>ctrl+u/v</kbd>), optionally using the system clipboard.
+- Cut (<kbd>ctrl+x</kbd>), copy (<kbd>ctrl+c</kbd>), paste (<kbd>ctrl+u/v</kbd>), optionally using the system clipboard. On terminals that support the Kitty keyboard protocol, the <kbd>cmd</kbd> equivalents work too.
+- Delete a word with <kbd>ctrl+backspace</kbd>, <kbd>alt+backspace</kbd>, or <kbd>alt+delete</kbd>.
 - Comment selections with <kbd>ctrl+/</kbd>.
 - Indent and dedent (optionally for a multiline selection) to tab stops with <kbd>Tab</kbd> and <kbd>shift+Tab</kbd>.
 - Automatic completions of quotes and brackets.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 license = "MIT"
 readme = "README.md"
 dependencies = [
-    "textual[syntax]>=6.4.0,<7",
+    "textual[syntax]>=8.2.8,<9",
     "pyperclip>=1.9.0,<2",
 ]
 
@@ -18,7 +18,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pre-commit>=3.3,<5",
-    "textual==6.4.0",
+    "textual==8.2.8",
     "textual-dev==1.8.0",
     "pyinstrument>=5,<6",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 license = "MIT"
 readme = "README.md"
 dependencies = [
-    "textual[syntax]>=8.2.8,<9",
+    "textual[syntax]>=7.3.0,<9",
     "pyperclip>=1.9.0,<2",
 ]
 

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -1116,7 +1116,21 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
         # self.text_input exists so watch_theme can do its thing.
         self.theme = self._theme
 
+    def focus(self, scroll_visible: bool = True) -> "TextEditor":
+        """
+        Focus the inner TextArea directly. Taking focus here first and then
+        forwarding it in on_focus would blur the TextArea on every call, and a
+        blur dismisses an open completion list.
+        """
+        if self.text_input is None:
+            super().focus(scroll_visible)
+        else:
+            self.text_input.focus(scroll_visible)
+        return self
+
     def on_focus(self) -> None:
+        # focus can also arrive from the focus chain (e.g. tab), which does not
+        # go through self.focus().
         if self.text_input is not None:
             self.text_input.focus()
 

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -126,30 +126,31 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
         Binding("shift+down", "cursor_down(True)", "cursor down select", show=False),
         Binding("shift+left", "cursor_left(True)", "cursor left select", show=False),
         Binding("shift+right", "cursor_right(True)", "cursor right select", show=False),
-        # Binding("f5", "select_word", "select word", show=False),
-        # Binding("f6", "select_line", "select line", show=False),
         Binding("ctrl+a", "select_all", "select all", show=False),
-        # Editing
+        # Editing. The super+ aliases are the cmd key on macOS; Textual reports
+        # them on terminals that support the Kitty keyboard protocol.
         Binding("ctrl+underscore", "toggle_comment", "toggle comment", show=False),
-        Binding("ctrl+x", "cut", "copy", show=False),
-        Binding("ctrl+c", "copy", "copy", show=False),
-        Binding("ctrl+u,ctrl+v,shift+insert", "paste", "paste", show=False),
-        Binding("ctrl+z", "undo", "undo", show=False),
-        Binding("ctrl+y", "redo", "redo", show=False),
+        Binding("ctrl+x,super+x", "cut", "cut", show=False),
+        Binding("ctrl+c,super+c", "copy", "copy", show=False),
+        Binding("ctrl+u,ctrl+v,super+v,shift+insert", "paste", "paste", show=False),
+        Binding("ctrl+z,super+z", "undo", "undo", show=False),
+        Binding("ctrl+y,super+y", "redo", "redo", show=False),
         # Deletion
         Binding("backspace", "delete_left", "delete left", show=False),
         Binding("delete", "delete_right", "delete right", show=False),
         Binding("shift+delete", "delete_line", "delete line", show=False),
-        # Binding(
-        #     "ctrl+w", "delete_word_left", "delete left to start of word", show=False
-        # ),
-        # Binding(
-        #     "ctrl+f", "delete_word_right", "delete right to start of word", show=False
-        # ),
-        # Binding(
-        #     "ctrl+u", "delete_to_start_of_line", "delete to line start", show=False
-        # ),
-        # Binding("ctrl+k", "delete_to_end_of_line", "delete to line end", show=False),
+        Binding(
+            "ctrl+backspace,alt+backspace",
+            "delete_word_left",
+            "delete left to start of word",
+            show=False,
+        ),
+        Binding(
+            "alt+delete",
+            "delete_word_right",
+            "delete right to start of word",
+            show=False,
+        ),
     ]
 
     clipboard: str = ""
@@ -460,6 +461,10 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
                 self.get_cursor_line_end_location(),
             )
             self.clipboard = f"{whole_line}{self.document.newline}"
+        # Textual's own clipboard: sets App.clipboard and emits OSC 52, which
+        # reaches the system clipboard over ssh and in terminals where pyperclip
+        # has no backend.
+        self.app.copy_to_clipboard(self.clipboard)
         if self.use_system_clipboard and self.system_copy is not None:
             try:
                 self.system_copy(self.clipboard)
@@ -1017,6 +1022,7 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
             self.post_message(TextAreaClipboardError(action="copy"))
             return
         self.text_input.clipboard = text
+        self.app.copy_to_clipboard(text)
         if self.use_system_clipboard and self.text_input.system_copy is not None:
             try:
                 self.text_input.system_copy(text)
@@ -1158,9 +1164,8 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
 
     @on(TextAreaPlus.Changed)
     def check_for_find_updates(self, event: TextAreaPlus.Changed) -> None:
-        try:
-            find_input = self.footer.query_one(FindInput)
-        except Exception:
+        find_input = self.footer.query_one_optional(FindInput)
+        if find_input is None:
             return
         self._update_find_label(value=find_input.value)
 
@@ -1325,12 +1330,9 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
         await self._mount_footer_path_input("open")
 
     async def action_find(self, prepopulate_from_history: bool = False) -> None:
-        try:
-            find_input = self.footer.query_one(FindInput)
-        except Exception:
-            pass
-        else:
-            find_input.focus()
+        existing_input = self.footer.query_one_optional(FindInput)
+        if existing_input is not None:
+            existing_input.focus()
             return
         if prepopulate_from_history and self._find_history:
             value = self._find_history[-1]
@@ -1344,12 +1346,9 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
         await self._mount_footer_input(input_widget=find_input)
 
     async def action_goto_line(self) -> None:
-        try:
-            goto_input = self.footer.query_one(GotoLineInput)
-        except Exception:
-            pass
-        else:
-            goto_input.focus()
+        existing_input = self.footer.query_one_optional(GotoLineInput)
+        if existing_input is not None:
+            existing_input.focus()
             return
         goto_input = GotoLineInput(
             max_line_number=self.text_input.document.line_count

--- a/tests/functional_tests/test_autocomplete.py
+++ b/tests/functional_tests/test_autocomplete.py
@@ -133,6 +133,31 @@ async def test_autocomplete(
 
 
 @pytest.mark.asyncio
+async def test_focus_does_not_dismiss_completion_list(
+    app: App, word_completer: Callable[[str], list[tuple[str, str]]]
+) -> None:
+    """
+    Focusing the TextEditor when it already holds focus must not blur the inner
+    TextArea, since the blur dismisses an open completion list.
+    """
+    async with app.run_test() as pilot:
+        ta = app.query_one("#ta", expect_type=TextEditor)
+        ta.word_completer = word_completer
+        assert ta.text_input is not None
+
+        await pilot.press("s")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert ta.completion_list.is_open is True
+
+        ta.focus()
+        await pilot.pause()
+        assert ta.text_input.has_focus is True
+        assert ta.text_input.completer_active == "word"
+        assert ta.completion_list.is_open is True
+
+
+@pytest.mark.asyncio
 async def test_autocomplete_with_types(
     app: App,
     word_completer_with_types: Callable[[str], list[tuple[tuple[str, str], str]]],

--- a/tests/functional_tests/test_textarea.py
+++ b/tests/functional_tests/test_textarea.py
@@ -246,6 +246,28 @@ from textual_textarea import TextEditor
             "bar\nbaz",
             Selection(start=(0, 0), end=(1, 0)),
         ),
+        # word deletion, using Textual's own delete_word_left/right actions
+        (
+            ["ctrl+backspace"],
+            "foo bar",
+            Selection(start=(0, 7), end=(0, 7)),
+            "foo ",
+            Selection(start=(0, 4), end=(0, 4)),
+        ),
+        (
+            ["alt+backspace"],
+            "foo bar",
+            Selection(start=(0, 7), end=(0, 7)),
+            "foo ",
+            Selection(start=(0, 4), end=(0, 4)),
+        ),
+        (
+            ["alt+delete"],
+            "foo bar",
+            Selection(start=(0, 0), end=(0, 0)),
+            " bar",
+            Selection(start=(0, 0), end=(0, 0)),
+        ),
     ],
 )
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -1294,7 +1294,7 @@ wheels = [
 
 [[package]]
 name = "textual"
-version = "6.4.0"
+version = "8.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py", extra = ["linkify"] },
@@ -1304,9 +1304,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/6c/565521dc6dd00fa857845483ae0c070575fda1f9a56d92d732554fecfea4/textual-6.4.0.tar.gz", hash = "sha256:f40df9165a001c10249698d532f2f5a71708b70f0e4ef3fce081a9dd93ffeaaa", size = 1573599, upload-time = "2025-10-22T17:29:51.357Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/20/6eed0e55bdd2576475e9cea49cc71c47f8e56ab54f04cbe04b2fb56440de/textual-6.4.0-py3-none-any.whl", hash = "sha256:b346dbb8e12f17cefb33ddfdf7f19bdc9e66c29daf82fc981a8db6b7d985e115", size = 711663, upload-time = "2025-10-22T17:29:49.346Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
 ]
 
 [package.optional-dependencies]
@@ -1390,14 +1390,14 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "pyperclip", specifier = ">=1.9.0,<2" },
-    { name = "textual", extras = ["syntax"], specifier = ">=6.4.0,<7" },
+    { name = "textual", extras = ["syntax"], specifier = ">=8.2.8,<9" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = ">=3.3,<5" },
     { name = "pyinstrument", specifier = ">=5,<6" },
-    { name = "textual", specifier = "==6.4.0" },
+    { name = "textual", specifier = "==8.2.8" },
     { name = "textual-dev", specifier = "==1.8.0" },
 ]
 static = [

--- a/uv.lock
+++ b/uv.lock
@@ -1390,7 +1390,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "pyperclip", specifier = ">=1.9.0,<2" },
-    { name = "textual", extras = ["syntax"], specifier = ">=8.2.8,<9" },
+    { name = "textual", extras = ["syntax"], specifier = ">=7.3.0,<9" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Bumps Textual from 6.4.0 to 8.2.8 and adopts what the newer `TextArea` provides.

Closes #312. Supersedes #322.

### Red (6bacd25)
Bumps the pin and adds a regression test. The upgrade exposes a latent bug in
this widget: `TextEditor.focus()` took focus itself and then handed it to the
inner `TextArea` via `on_focus`, so every call bounced focus off `TextAreaPlus`.
`on_blur` posts `TextAreaHideCompletionList`, and on Textual 8 that hide is now
processed *after* the `ShowCompletionList` it should have preceded, dismissing
the completion list and clearing `completer_active`.

### Green (80f37ef)
`focus()` now delegates straight to the inner `TextArea`. `Screen.set_focus`
no-ops when the widget already has focus, so no spurious `Blur` is emitted.
`on_focus` stays for focus arriving via the focus chain (tab).

### Refactor (c80f0d1)
- Drops four commented-out `Binding` stubs for actions upstream has long had.
  The word-deletion ones are now bound for real, on the combos Textual added in
  8.2.7/8.2.8: `ctrl+backspace`, `alt+backspace`, `alt+delete`.
- Adds `super+` (cmd) aliases for cut/copy/paste/undo/redo, which Textual reports
  on terminals speaking the Kitty keyboard protocol.
- Copy also writes through `App.copy_to_clipboard`, so the OSC 52 path covers ssh
  sessions and terminals where pyperclip finds no backend. pyperclip stays — it is
  still the only way to *read* the system clipboard on paste.
- Replaces three `try`/`except query_one` blocks with `query_one_optional` (7.3).

### On #312
Confirmed this is the same defect the reporter hit. At Textual 6.5.0, the
pre-upgrade tree reproduces the reported failure exactly (2 failed, 10 passed);
swapping in only the green fix turns it green (12 passed). The fix is therefore
independent of the version bump — but it ships on the new floor, so downstream
packagers will need to upgrade to pick it up.

`ctrl+u` stays bound to paste rather than upstream's `delete_to_start_of_line`,
and `ctrl+k`/`ctrl+w` stay unbound for host apps.

111 tests pass; ruff and mypy clean.