### PR TITLE
fix: scroll the cursor into view after replace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Adds <kbd>ctrl+backspace</kbd> and <kbd>alt+backspace</kbd> (delete word left) and <kbd>alt+delete</kbd> (delete word right), using Textual's own actions.
 - Adds <kbd>cmd</kbd> aliases for cut, copy, paste, undo, and redo, which Textual reports on terminals that support the Kitty keyboard protocol.
 - Copying now also writes to Textual's clipboard (which emits OSC 52), so copy works over ssh and in terminals where pyperclip has no backend.
+- Fixes a bug where pasting text or accepting a completion wider than the viewport left the cursor scrolled off-screen. Textual's `TextArea.replace()` scrolled the cursor into view through 6.4 but stopped in 7.x, so both call sites now scroll explicitly.
 
 ## [0.17.3] - 2026-08-03
 

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -286,6 +286,9 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
         self.post_message(TextAreaHideCompletionList())
         self.history.checkpoint()
         self.replace(event.text, *self.selection, maintain_selection_offset=False)
+        # replace() scrolled the cursor into view on Textual 6.4, but stopped
+        # doing so in 7.x, so pasting a long line left the cursor off-screen.
+        self.scroll_cursor_visible()
 
     @on(ClipboardReady)
     def _set_clipboard(self, message: ClipboardReady) -> None:
@@ -304,6 +307,8 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
             end=self.cursor_location,
             maintain_selection_offset=False,
         )
+        # see on_paste: replace() no longer scrolls the cursor into view.
+        self.scroll_cursor_visible()
 
     @work(thread=True)
     def _determine_clipboard(self) -> None:

--- a/tests/functional_tests/test_autocomplete.py
+++ b/tests/functional_tests/test_autocomplete.py
@@ -303,3 +303,48 @@ async def test_autocomplete_members(
         assert ta.text_input is not None
         assert ta.text_input.completer_active == "member"
         assert ta.completion_list.is_open is True
+
+
+@pytest.mark.asyncio
+async def test_accepting_completion_scrolls_cursor_into_view(app: App) -> None:
+    """
+    Accepting a completion wider than the viewport leaves the cursor on screen.
+
+    Same Textual 7.x behavior change as test_paste_scrolls_cursor_into_view:
+    replace() no longer scrolls the cursor into view on its own.
+    """
+    long_word = "s" + "u" * 150
+
+    def completer(prefix: str) -> list[tuple[str, str]]:
+        return [(long_word, long_word)]
+
+    async with app.run_test(size=(80, 24)) as pilot:
+        ta = app.query_one("#ta", expect_type=TextEditor)
+        ta.word_completer = completer
+        ta.focus()
+        while ta.word_completer is None:
+            await pilot.pause()
+        assert ta.text_input is not None
+
+        # start at the right edge of the viewport, but still on screen
+        prefix = "-" * 70
+        ta.text = prefix
+        ta.selection = Selection((0, len(prefix)), (0, len(prefix)))
+        await pilot.pause()
+        assert ta.text_input.scroll_offset.x == 0
+
+        start_time = monotonic()
+        await pilot.press("s")
+        while ta.completion_list.is_open is False:
+            if monotonic() - start_time > 10:
+                break
+            await pilot.pause()
+        assert ta.completion_list.is_open is True
+
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert ta.text == prefix + long_word
+        assert ta.selection.end[1] == len(prefix) + len(long_word)
+        assert ta.text_input.scroll_offset.x > 0

--- a/tests/functional_tests/test_textarea.py
+++ b/tests/functional_tests/test_textarea.py
@@ -4,7 +4,7 @@ from typing import List
 
 import pytest
 from textual.app import App
-from textual.events import MouseDown, MouseUp
+from textual.events import MouseDown, MouseUp, Paste
 from textual.pilot import _get_mouse_message_arguments
 from textual.widget import Widget
 from textual.widgets.text_area import Selection
@@ -559,3 +559,25 @@ async def test_click_chain_resets_at_a_new_location(app: App) -> None:
             await _click(app, text_input, (12, 1))
         await pilot.pause()
         assert ta.selection == Selection((1, 5), (1, 14))
+
+
+@pytest.mark.asyncio
+async def test_paste_scrolls_cursor_into_view(app: App) -> None:
+    """
+    Pasting a line wider than the viewport leaves the cursor on screen.
+
+    TextArea.replace() scrolled the cursor into view on Textual 6.4, but stopped
+    doing so in 7.x, so on_paste has to ask for the scroll itself.
+    """
+    async with app.run_test(size=(80, 24)) as pilot:
+        ta = app.query_one("#ta", expect_type=TextEditor)
+        text_input = ta.text_input
+        assert text_input is not None
+        ta.text = ""
+        await pilot.pause()
+
+        text_input.post_message(Paste("x" * 200))
+        await pilot.pause()
+
+        assert ta.selection == Selection((0, 200), (0, 200))
+        assert text_input.scroll_offset.x > 0


### PR DESCRIPTION
## Summary

Textual's `TextArea.replace()` scrolled the cursor into view through 6.4 but stopped in 7.x. Pasting a line wider than the viewport, or accepting a completion wider than the viewport, left the cursor off-screen.

## Changes

- Added a call to `scroll_cursor_visible()` after the `replace()` in `on_paste` and in `replace_current_word`.
- A regression test for each