### PR TITLE
fix: restore the cursor line highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fixes a bug where the line containing the cursor was no longer shaded. Textual computes `$boost` (which shades the cursor's line and gutter) only for themes that leave `panel` unset, so the shading disappeared for every built-in theme except `textual-dark`.
+
 ## [0.18.0] - 2026-08-05
 
 - **Breaking:** drops support for Textual &lt; 7.3.

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -69,6 +69,29 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
         &:focus {
             border: none;
         }
+
+        /* TextArea shades the cursor's line and gutter with $boost. Through
+        Textual 6, $boost was the contrast text at 4% alpha; since Textual 7 it
+        is only computed for themes that leave `panel` unset, so it is fully
+        transparent for every built-in theme but textual-dark, and the shading
+        disappears. Restore it with the value $boost used to have. */
+        &:dark {
+            & .text-area--cursor-line {
+                background: white 4%;
+            }
+            & .text-area--cursor-gutter {
+                background: white 4%;
+            }
+        }
+
+        &:light {
+            & .text-area--cursor-line {
+                background: black 4%;
+            }
+            & .text-area--cursor-gutter {
+                background: black 4%;
+            }
+        }
     }
     """
     BINDINGS = [


### PR DESCRIPTION
### The bug

The line containing the cursor is no longer shaded, for every theme but `textual-dark`.

### Cause

`.text-area--cursor-line` and `.text-area--cursor-gutter` both resolve to `background: $boost`, and that CSS is byte-identical between Textual 6.4.0 and 8.2.8. What changed is `$boost`. Textual 6 computed it unconditionally in `design.py`:

```python
boost = self.boost or contrast_text.with_alpha(0.04)
```

Textual 8 initializes it to `TRANSPARENT` and only assigns it *inside* the `if self.panel is None:` branch, so any theme that sets `panel` gets a fully transparent `$boost` and loses the shading. That is 19 of the 20 themes Harlequin ships — `textual-dark` is the only one that leaves `panel` unset.

### The fix

Set the two component classes directly on `TextAreaPlus`, from the contrast text, reproducing the value `$boost` had through Textual 6.

`white`/`black` at 4% rather than `$foreground 4%`: `$boost` was built from `contrast_text` — pure white or black — so `$foreground 4%` renders `#141414` where Textual 6 rendered `#151515`. `$text 4%` would have been the tidiest (`$text` is `auto 87%`, and `auto` *is* contrast-text) but Textual rejects `auto` for `background`.

### Verification

Resolved component styles inside the real Harlequin app, against the Textual 6.4.0 baseline:

|                            | cursor-line            | cursor-gutter                 |
| -------------------------- | ---------------------- | ----------------------------- |
| Textual 6.4.0 (baseline)   | `#dddddd on #151515`   | `bold #8d8d8d on #151515`     |
| Textual 8.2.8, unpatched   | `#dddddd on #0c0c0c`   | `bold #898989 on #0c0c0c`     |
| Textual 8.2.8, patched     | `#dddddd on #151515`   | `bold #8d8d8d on #151515`     |

Exact match, light themes too (`textual-light` → `#cfcfcf` in both versions).

Full suite passes (113 tests); ruff and mypy clean. No snapshot tests in this repo are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMbqzdwHVGdYhr8LyB6RRs