### PR TITLE
Suppress completions inside comments and string literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- The word and member completers no longer open when the cursor is inside a comment or a string literal ([#341](https://github.com/tconbeer/textual-textarea/issues/341), [harlequin/#803](https://github.com/tconbeer/harlequin/issues/803)). Typing inside a string used to open the word completer, and since the list preselects its first item, <kbd>enter</kbd> replaced what was typed with a completion. The path completer is unaffected, and neither are quoted identifiers (SQL's `"my col"`), which are identifiers, not strings.
+- Adds `suppress_completion_in_comments` and `suppress_completion_in_strings` arguments and properties to `TextEditor`, both defaulting to `True`, to restore the old behavior. A language with no comment or string nodes declared in the new `completion_scopes` module completes everywhere, as before.
+
 ## [0.18.1] - 2026-08-05
 
 - Fixes a bug where the line containing the cursor was no longer shaded. Textual computes `$boost` (which shades the cursor's line and gutter) only for themes that leave `panel` unset, so the shading disappeared for every built-in theme except `textual-dark`.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,20 @@ old_language = editor.language
 editor.language = "python"
 ```
 
+#### Autocompletion
+
+The TextEditor shows a completion list as the user types. You supply the completions by setting the `word_completer`, `member_completer`, and `path_completer` properties to callables that accept the text before the cursor and return a list of completions.
+
+The word and member completers stay closed when the cursor is inside a comment or a string literal, where a completion is noise -- and, because the list preselects its first option, destructive on <kbd>enter</kbd>. Two things keep working there: the path completer, since completing a path inside a string (`read_csv('/data/...`) is exactly what it is for, and completions after a quoted identifier, since SQL's `"my col"` and `` `my col` `` are identifiers, not strings.
+
+Which nodes count as a comment or a string depends on the configured language; they are declared per language in `textual_textarea/completion_scopes.py`, and a language declared in neither mapping completes everywhere. You can also turn either kind of suppression off:
+
+```python
+editor = TextEditor(language="sql", suppress_completion_in_strings=False)
+...
+editor.suppress_completion_in_comments = False
+```
+
 #### Getting Theme Colors
 
 If you would like the rest of your app to match the colors from the TextArea's theme, they are exposed via the `theme_colors` property.

--- a/src/textual_textarea/completion_scopes.py
+++ b/src/textual_textarea/completion_scopes.py
@@ -1,0 +1,168 @@
+"""
+Per-language declarations of the places where the word and member completers
+should stay closed.
+
+A string literal is the one place a user reliably does not want an identifier
+or keyword completion, and a comment is the same; because the completion list
+preselects its first option, offering one there means pressing enter replaces
+what was typed with a completion.
+
+Each mapping is keyed by the tree-sitter language name. A language that appears
+in neither ``COMMENT_NODES`` nor ``STRING_NODES`` never suppresses completion,
+so an unconfigured language behaves exactly as it did before this module
+existed.
+"""
+
+from __future__ import annotations
+
+from string import ascii_letters
+
+from textual_textarea.comments import INLINE_MARKERS
+
+# Node types for comments. Every node type here is unambiguously a comment, so
+# a cursor anywhere inside one suppresses completion.
+COMMENT_NODES: dict[str, tuple[str, ...]] = {
+    "bash": ("comment",),
+    "css": ("comment",),
+    "go": ("comment",),
+    "html": ("comment",),
+    "java": ("line_comment", "block_comment"),
+    "javascript": ("comment",),
+    "python": ("comment",),
+    "rust": ("line_comment", "block_comment"),
+    "sql": ("comment", "marginalia"),
+    "toml": ("comment",),
+    "xml": ("Comment",),
+    "yaml": ("comment",),
+}
+
+# Node types that may be string literals. A node type is not always enough on
+# its own: tree-sitter-sql parses 'abc', "my col", and 123 all to a `literal`
+# node, and only the first of those is a string -- a double-quoted name is an
+# identifier, and completing a member after it is exactly what a user wants. A
+# node of one of these types therefore counts as a string only if it opens with
+# one of the language's STRING_QUOTES.
+#
+# The document languages whose strings are the document's structure rather than
+# prose (JSON's keys and values, HTML and XML attribute values) are left out:
+# there, completing inside a string is the point.
+STRING_NODES: dict[str, tuple[str, ...]] = {
+    "bash": ("string", "raw_string"),
+    "css": ("string_value",),
+    "go": ("interpreted_string_literal", "raw_string_literal"),
+    "java": ("string_literal",),
+    "javascript": ("string", "template_string"),
+    "python": ("string",),
+    "rust": ("string_literal",),
+    "sql": ("literal",),
+    "toml": ("string",),
+    "yaml": ("single_quote_scalar", "double_quote_scalar"),
+}
+
+# The characters that open a string literal in each language, used both to tell
+# a string node from a quoted identifier and to scan for an unterminated string
+# (see is_string and ends_inside_string below).
+STRING_QUOTES: dict[str, tuple[str, ...]] = {
+    "bash": ("'", '"'),
+    "css": ("'", '"'),
+    "go": ('"', "`"),
+    "java": ('"',),
+    "javascript": ("'", '"', "`"),
+    "python": ("'", '"'),
+    "rust": ('"',),
+    # only the single quote: a lone $ is far more likely to be a Postgres
+    # placeholder ($1) or part of an identifier than the start of a
+    # dollar-quoted string, and ends_inside_string would read it as one.
+    "sql": ("'",),
+    "toml": ("'", '"'),
+    "yaml": ("'", '"'),
+}
+
+# Node types for the parts of a string that are code, not string content: the
+# braces of a Python f-string, the ${} of a JavaScript template literal. A
+# cursor inside one of these is writing an expression, and completions there
+# are as useful as they are anywhere else.
+INTERPOLATION_NODES: dict[str, tuple[str, ...]] = {
+    "javascript": ("template_substitution",),
+    "python": ("interpolation",),
+}
+
+# The delimiters of a block comment, for the fallback scan below. A line
+# comment's marker comes from comments.INLINE_MARKERS, which already carries
+# one per language.
+BLOCK_COMMENT_MARKERS: dict[str, tuple[str, str]] = {
+    "css": ("/*", "*/"),
+    "go": ("/*", "*/"),
+    "html": ("<!--", "-->"),
+    "java": ("/*", "*/"),
+    "javascript": ("/*", "*/"),
+    "rust": ("/*", "*/"),
+    "sql": ("/*", "*/"),
+    "xml": ("<!--", "-->"),
+}
+
+# Characters that can precede a string's opening quote as part of its literal:
+# SQL's N'abc' and E'abc', Python's rb'abc', Rust's br#"abc"#.
+_STRING_PREFIX_CHARS = f"{ascii_letters}&#"
+
+
+def is_string(language: str, opening_characters: str) -> bool:
+    """
+    Whether a node of a STRING_NODES type is a string literal, given the first
+    few characters of its text.
+
+    Args:
+        language (str): The tree-sitter language name.
+        opening_characters (str): The start of the node's text; must be long
+            enough to cover any string prefix and the quote that follows it.
+    """
+    quotes = STRING_QUOTES.get(language)
+    if quotes is None:
+        # the language declares string nodes but no quotes to disambiguate
+        # them, so every node of a declared type is a string.
+        return True
+    return opening_characters.lstrip(_STRING_PREFIX_CHARS)[:1] in quotes
+
+
+def scan_for_unterminated_scope(language: str, text: str) -> str | None:
+    """
+    Scan the text of a line up to the cursor and report the scope it leaves
+    open at its end: "string", "comment", or None.
+
+    An unterminated string or block comment doesn't parse to a node of its own
+    type -- the grammar leaves ERROR nodes behind, or recovers by parsing the
+    contents as an identifier -- so this backstops the syntax tree whenever the
+    tree has an error. It is deliberately naive: it knows about backslash
+    escapes and nothing else, and it starts at the beginning of the line, so a
+    string or block comment opened on an earlier line is invisible to it.
+
+    Args:
+        language (str): The tree-sitter language name.
+        text (str): The text to scan, the line before the cursor.
+    """
+    quotes = STRING_QUOTES.get(language, ())
+    line_marker = INLINE_MARKERS.get(language)
+    block_markers = BLOCK_COMMENT_MARKERS.get(language)
+    open_quote: str | None = None
+    escaped = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        index += 1
+        if escaped:
+            escaped = False
+        elif open_quote is not None:
+            if char == "\\":
+                escaped = True
+            elif char == open_quote:
+                open_quote = None
+        elif char in quotes:
+            open_quote = char
+        elif line_marker and text.startswith(line_marker, index - 1):
+            return "comment"
+        elif block_markers and text.startswith(block_markers[0], index - 1):
+            end = text.find(block_markers[1], index - 1 + len(block_markers[0]))
+            if end < 0:
+                return "comment"
+            index = end + len(block_markers[1])
+    return "string" if open_quote is not None else None

--- a/src/textual_textarea/text_editor.py
+++ b/src/textual_textarea/text_editor.py
@@ -23,6 +23,13 @@ from textual_textarea.autocomplete import CompletionList
 from textual_textarea.cancellable_input import CancellableInput
 from textual_textarea.colors import text_area_theme_from_app_theme
 from textual_textarea.comments import INLINE_MARKERS
+from textual_textarea.completion_scopes import (
+    COMMENT_NODES,
+    INTERPOLATION_NODES,
+    STRING_NODES,
+    is_string,
+    scan_for_unterminated_scope,
+)
 from textual_textarea.containers import FooterContainer, TextContainer
 from textual_textarea.error_modal import ErrorModal
 from textual_textarea.find_input import FindInput
@@ -178,6 +185,8 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
 
     clipboard: str = ""
     completer_active: Literal["path", "member", "word"] | None = None
+    suppress_completion_in_comments: bool = True
+    suppress_completion_in_strings: bool = True
 
     class ShowCompletionList(Message):
         def __init__(self, prefix: str) -> None:
@@ -211,6 +220,8 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
         theme: str = "css",
         use_system_clipboard: bool = True,
         read_only: bool = False,
+        suppress_completion_in_comments: bool = True,
+        suppress_completion_in_strings: bool = True,
         name: str | None = None,
         id: str | None = None,  # noqa: A002
         classes: str | None = None,
@@ -230,6 +241,8 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
             read_only=read_only,
         )
         self.cursor_blink = False if self.app.is_headless else True
+        self.suppress_completion_in_comments = suppress_completion_in_comments
+        self.suppress_completion_in_strings = suppress_completion_in_strings
         self.use_system_clipboard = use_system_clipboard
         self.system_copy: Callable[[Any], None] | None = None
         self.system_paste: Callable[[], str] | None = None
@@ -541,6 +554,122 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
         else:
             return ""
 
+    def _get_node_before_cursor(self) -> "Node" | None:
+        """
+        The innermost syntax tree node containing the character before the
+        cursor, or None if the document isn't parsed or the cursor is at the
+        start of it.
+
+        The character before the cursor, not the one at it: the cursor sits at
+        the end of the word being typed, and tree-sitter's point ranges are
+        half-open, so a point at the cursor itself is already outside the node
+        the word belongs to.
+        """
+        document = self.document
+        if not isinstance(document, SyntaxAwareDocument):
+            return None
+        location = self.get_cursor_left_location()
+        if location == self.cursor_location:
+            return None
+        row, column = location
+        point = (row, len(document.get_line(row)[:column].encode("utf-8")))
+        return document._syntax_tree.root_node.descendant_for_point_range(point, point)
+
+    def _get_node_opening_characters(self, node: "Node", count: int = 8) -> str:
+        """
+        The first count characters of a node's text, read from the document so
+        that a node spanning a large amount of text isn't copied on every
+        keypress.
+        """
+        row, byte_column = node.start_point
+        line = self.document.get_line(row).encode("utf-8")
+        return line[byte_column : byte_column + count].decode("utf-8", errors="ignore")
+
+    def _cursor_is_inside_node(
+        self, node: "Node", unclosed_at_end_of_line: bool = False
+    ) -> bool:
+        """
+        Whether the cursor is inside a node that contains the character before
+        it, as opposed to sitting just past the node's end.
+
+        The distinction matters at a closing delimiter: `"abc"` no longer
+        encloses the cursor once it is past the closing quote, and completing a
+        member of a string literal is a real thing to want. A comment that runs
+        to the end of its line has no closing delimiter to get past, though, so
+        callers pass unclosed_at_end_of_line for those. That does mean the
+        first character typed directly after a block comment that ends a line
+        gets no completions.
+        """
+        row, column = self.cursor_location
+        cursor_point = (row, len(self.document.get_line(row)[:column].encode("utf-8")))
+        if cursor_point < node.end_point:
+            return True
+        if not unclosed_at_end_of_line:
+            return False
+        end_row, end_byte_column = node.end_point
+        return end_byte_column >= len(self.document.get_line(end_row).encode("utf-8"))
+
+    def _cursor_is_in_no_completion_scope(self) -> bool:
+        """
+        Whether the cursor sits inside a comment or a string literal, where a
+        word or member completion is noise -- and, since the completion list
+        preselects its first option, destructive on enter.
+        """
+        language = self.language
+        if language is None:
+            return False
+        comment_nodes = (
+            COMMENT_NODES.get(language, ())
+            if self.suppress_completion_in_comments
+            else ()
+        )
+        string_nodes = (
+            STRING_NODES.get(language, ())
+            if self.suppress_completion_in_strings
+            else ()
+        )
+        if not comment_nodes and not string_nodes:
+            return False
+
+        interpolation_nodes = INTERPOLATION_NODES.get(language, ())
+        node = self._get_node_before_cursor()
+        while node is not None:
+            if node.type in interpolation_nodes:
+                # an f-string's braces (or a template literal's ${}) contain
+                # code, not string content.
+                return False
+            if node.type in comment_nodes and self._cursor_is_inside_node(
+                node, unclosed_at_end_of_line=True
+            ):
+                return True
+            if (
+                node.type in string_nodes
+                and is_string(language, self._get_node_opening_characters(node))
+                and self._cursor_is_inside_node(node)
+            ):
+                return True
+            node = node.parent
+
+        if self._syntax_tree_has_error():
+            # an unterminated string or block comment doesn't parse to a node
+            # of its own type, so fall back to scanning the line whenever the
+            # tree has an error.
+            row, column = self.cursor_location
+            scope = scan_for_unterminated_scope(
+                language, self.document.get_line(row)[:column]
+            )
+            if scope == "comment":
+                return bool(comment_nodes)
+            if scope == "string":
+                return bool(string_nodes)
+        return False
+
+    def _syntax_tree_has_error(self) -> bool:
+        document = self.document
+        if not isinstance(document, SyntaxAwareDocument):
+            return False
+        return bool(document._syntax_tree.root_node.has_error)
+
     def _handle_backspace(self, event: events.Key) -> None:
         if self.completer_active is not None:
             current_word = self._get_word_before_cursor(event)
@@ -615,6 +744,9 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
     def _handle_separator(self, event: events.Key) -> None:
         event.stop()
         if self.completer_active != "path":
+            if self._cursor_is_in_no_completion_scope():
+                self.post_message(TextAreaHideCompletionList())
+                return
             self.completer_active = "member"
         prefix = self._get_word_before_cursor(event)
         self.post_message(self.ShowCompletionList(prefix=prefix))
@@ -673,10 +805,12 @@ class TextAreaPlus(TextArea, inherit_bindings=False):
     def _handle_printable_character(self, event: events.Key) -> None:
         assert event.character is not None, "Error! Printable key with no character."
         if self.completer_active is None:
-            if WORD_PROG.match(event.character) is not None:
-                self.completer_active = "word"
-            else:
+            if WORD_PROG.match(event.character) is None:
                 return
+            if self._cursor_is_in_no_completion_scope():
+                self.post_message(TextAreaHideCompletionList())
+                return
+            self.completer_active = "word"
         current_word = self._get_word_before_cursor(event)
         if current_word:
             self.post_message(self.ShowCompletionList(prefix=current_word))
@@ -852,6 +986,8 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
         theme: str = "css",
         text: str = "",
         use_system_clipboard: bool = True,
+        suppress_completion_in_comments: bool = True,
+        suppress_completion_in_strings: bool = True,
         path_completer: (
             Callable[
                 [str],
@@ -885,6 +1021,12 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
             language (str): Must be the short name of a tree-sitter language,
                 e.g., "python", "sql"
             theme (str): Must be name of a Textual Theme.
+            suppress_completion_in_comments (bool): Set to False to offer word
+                and member completions inside comments.
+            suppress_completion_in_strings (bool): Set to False to offer word
+                and member completions inside string literals. The path
+                completer is unaffected either way: completing a path inside a
+                string is the whole point of it.
         """
         super().__init__(
             *children,
@@ -896,6 +1038,8 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
         self._language = language
         self._theme = theme
         self._initial_text = text
+        self._suppress_completion_in_comments = suppress_completion_in_comments
+        self._suppress_completion_in_strings = suppress_completion_in_strings
         self._find_history: list[str] = []
         self.use_system_clipboard = use_system_clipboard
         self.text_input: TextAreaPlus | None = None
@@ -984,6 +1128,36 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
         if self.text_input is None:
             return None
         self.text_input.language = language
+
+    @property
+    def suppress_completion_in_comments(self) -> bool:
+        """
+        Returns:
+            bool: Whether the word and member completers stay closed inside a
+            comment.
+        """
+        return self._suppress_completion_in_comments
+
+    @suppress_completion_in_comments.setter
+    def suppress_completion_in_comments(self, suppress: bool) -> None:
+        self._suppress_completion_in_comments = suppress
+        if self.text_input is not None:
+            self.text_input.suppress_completion_in_comments = suppress
+
+    @property
+    def suppress_completion_in_strings(self) -> bool:
+        """
+        Returns:
+            bool: Whether the word and member completers stay closed inside a
+            string literal. The path completer is unaffected either way.
+        """
+        return self._suppress_completion_in_strings
+
+    @suppress_completion_in_strings.setter
+    def suppress_completion_in_strings(self, suppress: bool) -> None:
+        self._suppress_completion_in_strings = suppress
+        if self.text_input is not None:
+            self.text_input.suppress_completion_in_strings = suppress
 
     @property
     def line_count(self) -> int:
@@ -1134,7 +1308,11 @@ class TextEditor(Widget, can_focus=True, can_focus_children=False):
     def compose(self) -> ComposeResult:
         self.text_container = TextContainer()
         self.text_input = TextAreaPlus(
-            language=self._language, text=self._initial_text, read_only=self.read_only
+            language=self._language,
+            text=self._initial_text,
+            read_only=self.read_only,
+            suppress_completion_in_comments=self._suppress_completion_in_comments,
+            suppress_completion_in_strings=self._suppress_completion_in_strings,
         )
         self.completion_list = CompletionList()
         self.footer = FooterContainer(classes="hide")

--- a/tests/functional_tests/conftest.py
+++ b/tests/functional_tests/conftest.py
@@ -1,4 +1,4 @@
-from typing import Type, Union
+from typing import Callable, Type, Union
 from unittest.mock import MagicMock
 
 import pytest
@@ -38,6 +38,45 @@ class TextEditorApp(App, inherit_bindings=False):
 def app() -> App:
     app = TextEditorApp(language="python")
     return app
+
+
+@pytest.fixture
+def sql_app() -> App:
+    app = TextEditorApp(language="sql")
+    return app
+
+
+@pytest.fixture
+def markdown_app() -> App:
+    app = TextEditorApp(language="markdown")
+    return app
+
+
+@pytest.fixture
+def word_completer() -> Callable[[str], list[tuple[str, str]]]:
+    def _completer(prefix: str) -> list[tuple[str, str]]:
+        words = [
+            "satisfy",
+            "season",
+            "second",
+            "seldom",
+            "select",
+            "self",
+            "separate",
+            "set",
+            "space",
+            "super",
+        ]
+        return [(w, w) for w in words if w.startswith(prefix)]
+
+    return _completer
+
+
+@pytest.fixture
+def member_completer() -> MagicMock:
+    mock = MagicMock()
+    mock.return_value = [("completion", "completion")]
+    return mock
 
 
 @pytest.fixture(

--- a/tests/functional_tests/test_autocomplete.py
+++ b/tests/functional_tests/test_autocomplete.py
@@ -14,26 +14,6 @@ from textual_textarea import TextEditor
 
 
 @pytest.fixture
-def word_completer() -> Callable[[str], list[tuple[str, str]]]:
-    def _completer(prefix: str) -> list[tuple[str, str]]:
-        words = [
-            "satisfy",
-            "season",
-            "second",
-            "seldom",
-            "select",
-            "self",
-            "separate",
-            "set",
-            "space",
-            "super",
-        ]
-        return [(w, w) for w in words if w.startswith(prefix)]
-
-    return _completer
-
-
-@pytest.fixture
 def word_completer_with_types() -> Callable[[str], list[tuple[tuple[str, str], str]]]:
     def _completer(prefix: str) -> list[tuple[tuple[str, str], str]]:
         words = [
@@ -51,13 +31,6 @@ def word_completer_with_types() -> Callable[[str], list[tuple[tuple[str, str], s
         return [((w, "word"), w) for w in words if w.startswith(prefix)]
 
     return _completer
-
-
-@pytest.fixture
-def member_completer() -> Callable[[str], list[tuple[str, str]]]:
-    mock = MagicMock()
-    mock.return_value = [("completion", "completion")]
-    return mock
 
 
 @pytest.mark.asyncio

--- a/tests/functional_tests/test_completion_scopes.py
+++ b/tests/functional_tests/test_completion_scopes.py
@@ -1,0 +1,306 @@
+"""
+The word and member completers stay closed inside comments and string literals.
+
+https://github.com/tconbeer/textual-textarea/issues/341
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+from textual.app import App
+from textual.pilot import Pilot
+from textual.widgets.text_area import Selection
+
+from textual_textarea import TextEditor
+
+
+@pytest.fixture
+def any_word_completer() -> MagicMock:
+    """A word completer that returns a completion for every prefix."""
+    mock = MagicMock()
+    mock.return_value = [("completion", "completion")]
+    return mock
+
+
+async def settle(app: App, pilot: Pilot) -> None:
+    """
+    Wait for the completer (which runs in a thread) and the messages it posts.
+    """
+    await app.workers.wait_for_complete()
+    await pilot.pause()
+    await app.workers.wait_for_complete()
+    await pilot.pause()
+
+
+@pytest.mark.asyncio
+async def test_no_completion_inside_string_literal(
+    sql_app: App, word_completer: Callable[[str], list[tuple[str, str]]]
+) -> None:
+    """
+    The bug from the issue: typing inside a string opened the word completer,
+    and since the list preselects its first item, enter replaced what was typed
+    with a completion.
+    """
+    async with sql_app.run_test() as pilot:
+        ta = sql_app.query_one("#ta", expect_type=TextEditor)
+        ta.word_completer = word_completer
+        ta.focus()
+        await pilot.pause()
+        ta.text = "select "
+        ta.selection = Selection((0, 7), (0, 7))
+        await pilot.pause()
+
+        await pilot.press("apostrophe")  # auto-closes to select ''
+        await settle(sql_app, pilot)
+        assert ta.text == "select ''"
+
+        await pilot.press("s", "e")
+        await settle(sql_app, pilot)
+        assert ta.text == "select 'se'"
+        assert ta.text_input is not None
+        assert ta.text_input.completer_active is None
+        assert ta.completion_list.is_open is False
+
+        await pilot.press("enter")
+        await settle(sql_app, pilot)
+        assert ta.text == "select 'se\n'"
+
+
+@pytest.mark.parametrize(
+    "text,keys",
+    [
+        ("select 'se", ["l"]),  # unterminated string; the tree has ERROR nodes
+        ("select 'sel'", ["e"]),  # cursor between the l and the closing quote
+        ("select -- s", ["e"]),
+        ("select 1 -- se", ["l"]),
+        ("select /* s", ["e"]),  # unterminated block comment
+        ("select /* se */", ["l"]),
+        ("select 'a\nse'", ["l"]),  # a string that spans lines
+    ],
+)
+@pytest.mark.asyncio
+async def test_no_completion_in_no_completion_scopes(
+    sql_app: App,
+    word_completer: Callable[[str], list[tuple[str, str]]],
+    text: str,
+    keys: list[str],
+) -> None:
+    async with sql_app.run_test() as pilot:
+        ta = sql_app.query_one("#ta", expect_type=TextEditor)
+        ta.word_completer = word_completer
+        lines = text.split("\n")
+        ta.focus()
+        await pilot.pause()
+        ta.text = text
+        cursor = (len(lines) - 1, len(lines[-1]))
+        # a terminated literal or comment puts the cursor inside it
+        if text.endswith(("'", "*/")):
+            cursor = (cursor[0], cursor[1] - (1 if text.endswith("'") else 3))
+        ta.selection = Selection(cursor, cursor)
+        await pilot.pause()
+        for key in keys:
+            await pilot.press(key)
+        await settle(sql_app, pilot)
+
+        assert ta.text_input is not None
+        assert ta.text_input.completer_active is None
+        assert ta.completion_list.is_open is False
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "select se",
+        "select 'abc', se",
+        "select 1 -- a comment\nse",
+        "select /* a comment */ se",
+        "select 123",  # a number is a sql literal, but it isn't a string
+        'select "se',  # a quoted identifier, not a string
+    ],
+)
+@pytest.mark.asyncio
+async def test_completion_outside_no_completion_scopes(
+    sql_app: App, any_word_completer: MagicMock, text: str
+) -> None:
+    async with sql_app.run_test() as pilot:
+        ta = sql_app.query_one("#ta", expect_type=TextEditor)
+        ta.word_completer = any_word_completer
+        ta.focus()
+        await pilot.pause()
+        lines = text.split("\n")
+        ta.text = text
+        cursor = (len(lines) - 1, len(lines[-1]))
+        ta.selection = Selection(cursor, cursor)
+        await pilot.pause()
+
+        await pilot.press("l")
+        await settle(sql_app, pilot)
+        assert ta.text_input is not None
+        assert ta.text_input.completer_active == "word"
+        assert ta.completion_list.is_open is True
+
+
+@pytest.mark.parametrize(
+    "text,expected_prefix",
+    [
+        ('select "my col"', '"my col".'),  # a quoted identifier
+        ("select `my col`", "`my col`."),
+        ("select my_tbl", "my_tbl."),
+    ],
+)
+@pytest.mark.asyncio
+async def test_member_completion_after_identifiers(
+    sql_app: App, member_completer: MagicMock, text: str, expected_prefix: str
+) -> None:
+    """
+    In SQL, "my col" and `my col` are identifiers, not strings, and members
+    after them are worth completing.
+    """
+    async with sql_app.run_test() as pilot:
+        ta = sql_app.query_one("#ta", expect_type=TextEditor)
+        ta.member_completer = member_completer
+        ta.focus()
+        await pilot.pause()
+        ta.text = text
+        ta.selection = Selection((0, len(text)), (0, len(text)))
+        await pilot.pause()
+
+        await pilot.press("full_stop")
+        await settle(sql_app, pilot)
+        assert ta.text_input is not None
+        assert ta.text_input.completer_active == "member"
+        member_completer.assert_called_with(expected_prefix)
+        assert ta.completion_list.is_open is True
+
+
+@pytest.mark.asyncio
+async def test_no_member_completion_inside_string_literal(
+    sql_app: App, member_completer: MagicMock
+) -> None:
+    async with sql_app.run_test() as pilot:
+        ta = sql_app.query_one("#ta", expect_type=TextEditor)
+        ta.member_completer = member_completer
+        ta.focus()
+        await pilot.pause()
+        ta.text = "select 'my_tbl'"
+        ta.selection = Selection((0, 14), (0, 14))
+        await pilot.pause()
+
+        await pilot.press("full_stop")
+        await settle(sql_app, pilot)
+        assert ta.text == "select 'my_tbl.'"
+        assert ta.text_input is not None
+        assert ta.text_input.completer_active is None
+        assert ta.completion_list.is_open is False
+        member_completer.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_path_completion_still_works_inside_string_literal(
+    sql_app: App,
+) -> None:
+    """
+    Completing a path inside a string is the whole point of the path completer,
+    so it is never suppressed.
+    """
+    async with sql_app.run_test() as pilot:
+        ta = sql_app.query_one("#ta", expect_type=TextEditor)
+        ta.focus()
+        await pilot.pause()
+        ta.text = "select * from read_csv('')"
+        ta.selection = Selection((0, 24), (0, 24))
+        await pilot.pause()
+
+        await pilot.press("slash")
+        await settle(sql_app, pilot)
+        assert ta.text_input is not None
+        assert ta.text_input.completer_active == "path"
+
+
+@pytest.mark.asyncio
+async def test_suppression_can_be_disabled(
+    sql_app: App, word_completer: Callable[[str], list[tuple[str, str]]]
+) -> None:
+    async with sql_app.run_test() as pilot:
+        ta = sql_app.query_one("#ta", expect_type=TextEditor)
+        ta.word_completer = word_completer
+        ta.suppress_completion_in_strings = False
+        ta.suppress_completion_in_comments = False
+        ta.focus()
+        await pilot.pause()
+        assert ta.text_input is not None
+        assert ta.text_input.suppress_completion_in_strings is False
+        assert ta.text_input.suppress_completion_in_comments is False
+
+        ta.text = "select 'se'"
+        ta.selection = Selection((0, 10), (0, 10))
+        await pilot.pause()
+        await pilot.press("l")
+        await settle(sql_app, pilot)
+        assert ta.text_input.completer_active == "word"
+        assert ta.completion_list.is_open is True
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_language_completes_everywhere(
+    markdown_app: App, word_completer: Callable[[str], list[tuple[str, str]]]
+) -> None:
+    """
+    A language with no declared comment or string nodes behaves exactly as it
+    did before those declarations existed.
+    """
+    async with markdown_app.run_test() as pilot:
+        ta = markdown_app.query_one("#ta", expect_type=TextEditor)
+        ta.word_completer = word_completer
+        ta.focus()
+        await pilot.pause()
+        ta.text = "'se"
+        ta.selection = Selection((0, 3), (0, 3))
+        await pilot.pause()
+
+        await pilot.press("l")
+        await settle(markdown_app, pilot)
+        assert ta.text_input is not None
+        assert ta.text_input.completer_active == "word"
+        assert ta.completion_list.is_open is True
+
+
+@pytest.mark.parametrize(
+    "text,cursor,expected_active",
+    [
+        ("x = 'se'", 7, None),
+        ("x = 1  # se", 11, None),
+        ('x = """\nse"""', 2, None),
+        ('x = f"{se}"', 9, "word"),  # an f-string's braces contain code
+        ("x = se", 6, "word"),
+        ('x = "se".uppe', 13, "word"),  # a member of a string literal
+    ],
+)
+@pytest.mark.asyncio
+async def test_python_scopes(
+    app: App,
+    any_word_completer: MagicMock,
+    text: str,
+    cursor: int | None,
+    expected_active: str | None,
+) -> None:
+    async with app.run_test() as pilot:
+        ta = app.query_one("#ta", expect_type=TextEditor)
+        ta.word_completer = any_word_completer
+        ta.focus()
+        await pilot.pause()
+        lines = text.split("\n")
+        ta.text = text
+        row = len(lines) - 1
+        column = len(lines[-1]) if cursor is None else cursor
+        ta.selection = Selection((row, column), (row, column))
+        await pilot.pause()
+
+        await pilot.press("l")
+        await settle(app, pilot)
+        assert ta.text_input is not None
+        assert ta.text_input.completer_active == expected_active
+        assert ta.completion_list.is_open is (expected_active is not None)

--- a/tests/unit_tests/test_completion_scopes.py
+++ b/tests/unit_tests/test_completion_scopes.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from textual_textarea.completion_scopes import is_string, scan_for_unterminated_scope
+
+
+@pytest.mark.parametrize(
+    "language,opening_characters,expected",
+    [
+        ("sql", "'abc'", True),
+        ("sql", "N'abc'", True),  # a prefixed string literal
+        ("sql", "E'abc'", True),
+        ("sql", '"my col"', False),  # a quoted identifier, not a string
+        ("sql", "`my col`", False),
+        ("sql", "123", False),  # tree-sitter-sql parses a number to a literal
+        ("python", "'abc'", True),
+        ("python", '"""abc', True),
+        ("python", 'rb"abc"', True),
+        ("rust", 'br#"abc', True),
+        ("javascript", "`abc`", True),
+        ("markdown", "'abc'", True),  # no declared quotes; every node counts
+    ],
+)
+def test_is_string(language: str, opening_characters: str, expected: bool) -> None:
+    assert is_string(language, opening_characters) is expected
+
+
+@pytest.mark.parametrize(
+    "language,text,expected",
+    [
+        ("sql", "select 'ab", "string"),
+        ("sql", "select 'ab'", None),
+        ("sql", "select 'it''s ab", "string"),
+        ("sql", "select 'it''s'", None),
+        ("sql", 'select "my col", ab', None),  # a quoted identifier
+        ("sql", "select $1, ab", None),  # a placeholder, not a dollar quote
+        ("sql", "select 1 -- ab", "comment"),
+        ("sql", "select 1 -- don't ab", "comment"),  # the quote is commented out
+        ("sql", "select '-- not a comment", "string"),
+        ("sql", "select /* ab", "comment"),
+        ("sql", "select /* ab */ cd", None),
+        ("sql", "select /* ab */ 'cd", "string"),
+        ("python", "x = 'ab", "string"),
+        ("python", "x = 'a\\'b", "string"),  # an escaped quote
+        ("python", "x = 1  # ab", "comment"),
+        ("python", "x = 1", None),
+        ("python", "x = '#ab", "string"),
+        ("markdown", "'ab", None),  # an unconfigured language never suppresses
+    ],
+)
+def test_scan_for_unterminated_scope(
+    language: str, text: str, expected: str | None
+) -> None:
+    assert scan_for_unterminated_scope(language, text) == expected


### PR DESCRIPTION
## Summary

This PR prevents the word and member completers from opening when the cursor is inside a comment or string literal, addressing issue #341. The path completer continues to work in strings since completing file paths inside strings is its intended use case.

## Key Changes

- **New module `completion_scopes.py`**: Declares per-language syntax tree node types for comments and string literals, along with helper functions to detect when the cursor is in these scopes. Includes language-specific configurations for bash, CSS, Go, Java, JavaScript, Python, Rust, SQL, TOML, XML, and YAML.

- **Enhanced `TextAreaPlus` class**: 
  - Added `suppress_completion_in_comments` and `suppress_completion_in_strings` boolean properties (both default to `True`)
  - Implemented `_cursor_is_in_no_completion_scope()` method that checks the syntax tree to determine if the cursor is inside a comment or string
  - Added helper methods `_get_node_before_cursor()`, `_get_node_opening_characters()`, `_cursor_is_inside_node()`, and `_syntax_tree_has_error()` to support scope detection
  - Modified `_handle_separator()` and `_handle_printable_character()` to check scopes before activating completers

- **Updated `TextEditor` class**: Added corresponding properties to expose the suppression settings to users, with getters and setters that propagate changes to the underlying `TextAreaPlus` instance.

- **Comprehensive test coverage**:
  - Functional tests covering various scenarios: unterminated strings, block comments, line comments, multi-line strings, and language-specific edge cases
  - Tests verifying that completions still work outside these scopes
  - Tests for member completions after quoted identifiers (which should work in SQL)
  - Tests confirming path completions work inside strings
  - Tests showing the suppression can be disabled
  - Unit tests for the `is_string()` and `scan_for_unterminated_scope()` helper functions

## Implementation Details

- The solution uses tree-sitter's syntax tree to identify comment and string nodes. When the tree has errors (e.g., unterminated strings), it falls back to a line-by-line scan that detects unclosed quotes and block comments.
- String detection is language-aware: in SQL, single quotes open strings while double quotes open identifiers, so the code checks the opening character to disambiguate.
- Interpolation nodes (f-string braces in Python, template substitutions in JavaScript) are treated as code, allowing completions within them.
- Languages without declared comment or string nodes behave as before, offering completions everywhere.

https://claude.ai/code/session_016AxpFxc65rCh7NvusASXZq